### PR TITLE
Remove `atomic` from `handshake`

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -87,7 +87,7 @@ impl ConnectionExt for ConnectionConfig {
         let mut write_half = WriteTransport::V1(self.network().default_network_magic());
         let mut read_half = ReadTransport::V1(self.network().default_network_magic());
         write_half.write_message(NetworkMessage::Version(version), &mut tcp_stream)?;
-        let (handshake, messages) = match read_half.read_message(&mut tcp_stream)? {
+        let (mut handshake, messages) = match read_half.read_message(&mut tcp_stream)? {
             Some(message) => self.start_handshake(unix_time, message, nonce)?,
             None => return Err(Error::MissingVersion),
         };
@@ -106,9 +106,11 @@ impl ConnectionExt for ConnectionConfig {
                             feeler,
                             their_preferences,
                         } = completed_handshake;
+                        let atomic_preferences =
+                            Arc::new(Preferences::from_dynamic(their_preferences));
                         let live_connection = ConnectionMetrics {
                             feeler,
-                            their_preferences: Arc::clone(&their_preferences),
+                            their_preferences: Arc::clone(&atomic_preferences),
                             timed_messages: Arc::clone(&timed_messages),
                             start_time: Instant::now(),
                         };
@@ -128,7 +130,7 @@ impl ConnectionExt for ConnectionConfig {
                         let reader = ConnectionReader {
                             tcp_stream,
                             transport: read_half,
-                            their_preferences,
+                            their_preferences: atomic_preferences,
                             timed_messages,
                         };
                         return Ok((writer, reader, live_connection));
@@ -237,8 +239,12 @@ impl ConnectionReader {
             match message {
                 NetworkMessage::SendHeaders => self.their_preferences.prefers_header_announcment(),
                 NetworkMessage::SendCmpct(cmpct) => {
-                    self.their_preferences.prefers_cmpct(cmpct.version)
+                    if cmpct.send_compact {
+                        self.their_preferences.prefers_cmpct();
+                    }
                 }
+                NetworkMessage::SendAddrV2 => self.their_preferences.prefers_addrv2(),
+                NetworkMessage::WtxidRelay => self.their_preferences.prefers_wtxid(),
                 NetworkMessage::Block(_) => {
                     if let Ok(mut lock) = self.timed_messages.lock() {
                         lock.add_single(TimedMessage::Block, Instant::now());


### PR DESCRIPTION
While the negotiation is live, there is no shared state between reader/writer/metrics. Preferences may be updated as mutable. Once the conneciton is live, the preferences become shared state.

I am taking a lazy approach right now on `sendcmpct`, but eventually the lowest common version must also be negotiated and saved. Perhaps a little gross, but I decided to make a new struct that is the mutable counterpart to `Preferences`. It is an internal type, so there is no caller confusion.

Closes #4 